### PR TITLE
Add Optimizer Callbacks

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -826,7 +826,7 @@ pub fn main() {
 
                 // Optimize
                 let report = lbfgs
-                    .optimize(&problem, Some(initial_guesses))
+                    .optimize(&problem, Some(initial_guesses), None)
                     .expect("Failed to optimize");
 
                 // Display the results
@@ -879,7 +879,7 @@ pub fn main() {
 
                 // Optimize
                 let report = bfgs
-                    .optimize(&problem, Some(initial_guesses))
+                    .optimize(&problem, Some(initial_guesses), None)
                     .expect("Failed to optimize");
 
                 // Display the results
@@ -932,7 +932,7 @@ pub fn main() {
 
                 // Optimize
                 let report = sr1trustregion
-                    .optimize(&problem, Some(initial_guesses))
+                    .optimize(&problem, Some(initial_guesses), None)
                     .expect("Failed to optimize");
 
                 // Display the results
@@ -984,7 +984,7 @@ pub fn main() {
 
                 // Optimize
                 let report = optimizer
-                    .optimize(&problem, None::<InitialGuesses>)
+                    .optimize(&problem, None::<InitialGuesses>, None)
                     .expect("Failed to optimize");
 
                 // Display the results
@@ -1032,7 +1032,7 @@ pub fn main() {
 
                 // Optimize
                 let report = optimizer
-                    .optimize(&problem, None::<InitialGuesses>)
+                    .optimize(&problem, None::<InitialGuesses>, None)
                     .expect("Failed to optimize");
 
                 // Display the results

--- a/src/identifiability/utils.rs
+++ b/src/identifiability/utils.rs
@@ -75,7 +75,7 @@ where
     }
 
     // Optimize the problem
-    let report = optimizer.optimize(&problem, Some(initial_guess))?;
+    let report = optimizer.optimize(&problem, Some(initial_guess), None)?;
     let ratio = likelihood_ratio(err_min, report.error);
 
     Ok((param_values, report.error, ratio))
@@ -236,7 +236,7 @@ where
 
     // First, fit the problem to get the initial guess
     let initial_guess = initial_guess.into();
-    let report = optimizer.optimize(problem, Some(initial_guess))?;
+    let report = optimizer.optimize(problem, Some(initial_guess), None)?;
     let err_min = report.error;
 
     // Use the optimized parameters as the initial guess

--- a/src/optim/observer.rs
+++ b/src/optim/observer.rs
@@ -47,6 +47,12 @@ where
     }
 }
 
+impl CallbackObserver {
+    pub fn new(callback: Box<dyn Fn(f64, f64) + UnwindSafe + Send>) -> Self {
+        Self { callback }
+    }
+}
+
 /// A progress bar observer that displays optimization progress.
 ///
 /// The `ProgressObserver` implements the `Observe` trait from the argmin library and

--- a/src/optim/optimizers/ego.rs
+++ b/src/optim/optimizers/ego.rs
@@ -19,8 +19,8 @@ use peroxide::fuga::ODEIntegrator;
 
 use crate::{
     optim::{
-        bounds_to_array2, report::OptimizationReport, Bound, InitialGuesses, OptimizeError,
-        Optimizer, Problem,
+        bounds_to_array2, observer::CallbackObserver, report::OptimizationReport, Bound,
+        InitialGuesses, OptimizeError, Optimizer, Problem,
     },
     prelude::ObjectiveFunction,
 };
@@ -70,6 +70,7 @@ impl<S: ODEIntegrator + Copy + Send + Sync, L: ObjectiveFunction> Optimizer<S, L
         &self,
         problem: &Problem<S, L>,
         _: Option<T>,
+        _: Option<CallbackObserver>,
     ) -> Result<OptimizationReport, OptimizeError>
     where
         T: Into<InitialGuesses>,

--- a/src/optim/optimizers/optimizer.rs
+++ b/src/optim/optimizers/optimizer.rs
@@ -9,6 +9,7 @@
 use ndarray::Array1;
 use peroxide::fuga::ODEIntegrator;
 
+use crate::optim::observer::CallbackObserver;
 use crate::optim::report::OptimizationReport;
 use crate::prelude::ObjectiveFunction;
 use crate::{optim::problem::Problem, prelude::EnzymeMLDocument};
@@ -29,6 +30,7 @@ pub trait Optimizer<S: ODEIntegrator + Copy, L: ObjectiveFunction> {
         &self,
         problem: &Problem<S, L>,
         initial_guess: Option<T>,
+        callbacks: Option<CallbackObserver>,
     ) -> Result<OptimizationReport, OptimizeError>
     where
         T: Into<InitialGuesses>;

--- a/tests/test_optim.rs
+++ b/tests/test_optim.rs
@@ -46,7 +46,7 @@ mod test_optim {
 
         let inits = Array1::from_vec(vec![80.0, 0.83, 0.0009]);
         let res = bfgs
-            .optimize(&problem, Some(inits))
+            .optimize(&problem, Some(inits), None)
             .expect("Failed to optimize");
 
         // ASSERT
@@ -80,7 +80,7 @@ mod test_optim {
 
         let inits = Array1::from_vec(vec![80.0, 0.83, 0.0009]);
         let res = lbfgs
-            .optimize(&problem, Some(inits))
+            .optimize(&problem, Some(inits), None)
             .expect("Failed to optimize");
 
         // ASSERT
@@ -113,7 +113,7 @@ mod test_optim {
 
         let inits = Array1::from_vec(vec![80.0, 0.83, 0.0009]);
         let res = sr1trustregion
-            .optimize(&problem, Some(inits))
+            .optimize(&problem, Some(inits), None)
             .expect("Failed to optimize");
 
         // ASSERT
@@ -146,7 +146,7 @@ mod test_optim {
 
         let inits = Array1::from_vec(vec![80.0, 0.83, 0.0009]);
         let res = sr1trustregion
-            .optimize(&problem, Some(inits))
+            .optimize(&problem, Some(inits), None)
             .expect("Failed to optimize");
 
         // ASSERT
@@ -178,7 +178,7 @@ mod test_optim {
             .build();
 
         let res = pso
-            .optimize(&problem, None::<Array1<f64>>)
+            .optimize(&problem, None::<Array1<f64>>, None)
             .expect("Failed to optimize");
 
         // ASSERT
@@ -209,7 +209,7 @@ mod test_optim {
             .bound("k_cat", 0.8, 0.9)
             .bound("k_ie", 0.0005, 0.0015)
             .build()
-            .optimize(&problem, None::<Array1<f64>>)
+            .optimize(&problem, None::<Array1<f64>>, None)
             .unwrap();
 
         // ASSERT
@@ -245,7 +245,7 @@ mod test_optim {
 
         let inits = Array1::from_vec(vec![80.0, 0.83, 0.0009]);
         let res = sr1trustregion
-            .optimize(&problem, Some(inits))
+            .optimize(&problem, Some(inits), None)
             .expect("Failed to optimize");
 
         // ASSERT
@@ -280,7 +280,7 @@ mod test_optim {
 
         let inits = Array1::from_vec(vec![80.0, 0.83]);
         let res = sr1trustregion
-            .optimize(&problem, Some(inits))
+            .optimize(&problem, Some(inits), None)
             .expect("Failed to optimize");
 
         // ASSERT


### PR DESCRIPTION
This pull request introduces a new `CallbackObserver` to allow custom callback functions during optimization processes. It modifies the `Optimizer` trait and its implementations to support this feature, updates related tests, and ensures backward compatibility by adding a `None` default for the callback parameter.

### Core Enhancements:

#### Callback Functionality:
* Added a new `CallbackObserver` struct with a `new` method to encapsulate user-defined callback functions.
* Updated the `Optimizer` trait to include an optional `CallbackObserver` parameter for optimization methods.

#### Integration with Optimizers:
* Modified all optimizer implementations (`BFGS`, `LBFGS`, `PSO`, `SR1 Trust Region`) to accept and handle the `CallbackObserver`. This includes changes to their function signatures and execution flows to add the observer if provided.

#### Solver-Specific Updates:
* Adjusted `solve_steihaug` and `solve_cauchy_point` methods in the `SR1 Trust Region` implementation to include the `CallbackObserver`.

### Testing Updates:
* Updated all test cases in `tests/test_optim.rs` to include the new `None` parameter for the callback, ensuring compatibility with the modified method signatures.

These changes provide a flexible mechanism for users to monitor or influence the optimization process while maintaining compatibility with existing code.